### PR TITLE
Fix encoding and 2->3 transition in Kindle reader

### DIFF
--- a/readers/Kindle.py
+++ b/readers/Kindle.py
@@ -17,7 +17,7 @@ from calibre.utils.date import parse_date
 from calibre_plugins.annotations.reader_app_support import USBReader
 from calibre_plugins.annotations.common_utils import (AnnotationStruct, BookStruct)
 
-KINDLE_FORMATS = [u'azw', u'azw1', u'azw3', 'kfx', u'mobi', u'pdf']
+KINDLE_FORMATS = ['azw', 'azw1', 'azw3', 'kfx', 'mobi', 'pdf']
 KINDLE_TEMPLATES = ['*.azw', '*.azw3', '*.kfx', '*.mobi', '*.pobi', '*.pdf']
 MY_CLIPPINGS_FILENAMES = ['My Clippings.txt', 'Meine Clippings.txt']
 
@@ -330,13 +330,13 @@ class KindleReaderApp(USBReader):
         annos = ParseKindleMyClippingsTxt.FromFileName(self._get_my_clippings())
         self._log(" Number of entries retrieved from 'My Clippings.txt'=%d" % (len(annos)))
         for anno in annos:
-            title = anno.title.decode('utf-8')
+            title = anno.title
             self._log("  Annotation for Title=='%s'" % (title))
             # If title/author_sort match book in library,
             # consider this an active annotation
             book_id = None
             title = title.strip()
-            if title in self.installed_books_by_title.keys():
+            if title in list(self.installed_books_by_title.keys()):
                 book_id = self.installed_books_by_title[title]['book_id']
                 self._log("    Found book_id=%d" % (book_id))
             if not book_id:
@@ -357,9 +357,9 @@ class KindleReaderApp(USBReader):
                 'location_sort': "%06d" % anno.begin if anno.begin is not None else "000000"
                 }
             if anno.kind == 'highlight':
-                self.active_annotations[timestamp]['highlight_text'] = anno.text.decode('utf-8').split(u'\n')
+                self.active_annotations[timestamp]['highlight_text'] = anno.text.split('\n')
             elif anno.kind == 'note':
-                self.active_annotations[timestamp]['note_text'] = anno.text.decode('utf-8').split(u'\n')
+                self.active_annotations[timestamp]['note_text'] = anno.text.split('\n')
             else:
                 self._log("    Clipping is not a highlight or note")
 
@@ -374,10 +374,9 @@ class KindleReaderApp(USBReader):
         if cp:
             lines = []
             # Apparently new MyClippings.txt files are encoded UTF-8 with BOM
-            with open(cp) as clippings:
+            with open(cp, encoding='utf-8-sig') as clippings:
                 for line in clippings:
-                    stripped = line.decode('utf-8-sig')
-                    lines.append(stripped)
+                    lines.append(line)
 
             index = 0
             line = lines[index]
@@ -401,7 +400,7 @@ class KindleReaderApp(USBReader):
                     author_sort = tas.group('author_sort')
                     # If title/author_sort match book in library,
                     # consider this an active annotation
-                    if title in self.installed_books_by_title.keys():
+                    if title in list(self.installed_books_by_title.keys()):
                         book_id = self.installed_books_by_title[title]['book_id']
                     index += 1
 
@@ -448,16 +447,16 @@ class KindleReaderApp(USBReader):
                     highlight_text = None
                     note_text = None
                     if ann_type == 'Highlight':
-                        highlight_text = [unicode(item)]
+                        highlight_text = [str(item)]
                         index += 1
                         while lines[index].strip() != SEPARATOR:
-                            highlight_text.append(unicode(lines[index]))
+                            highlight_text.append(str(lines[index]))
                             index += 1
                     elif ann_type == 'Note':
-                        note_text = [unicode(item)]
+                        note_text = [str(item)]
                         index += 1
                         while lines[index].strip() != SEPARATOR:
-                            note_text.append(unicode(lines[index]))
+                            note_text.append(str(lines[index]))
                             index += 1
                     # Pass SEPARATOR
                     index += 1

--- a/readers/ParseKindleMyClippingsTxt.py
+++ b/readers/ParseKindleMyClippingsTxt.py
@@ -308,7 +308,7 @@ def FromFileName(myClippingsFilePath):
 
 def FromUtf8String(myClippingsTxt):
     # remove BOM(s) a.k.a. zero width space
-    myClippingsTxt = myClippingsTxt.replace('﻿', '')
+    myClippingsTxt = myClippingsTxt.replace(b'\xef\xbb\xbf'.decode('utf-8'), '')
     # normalize newlines
     myClippingsTxt = myClippingsTxt.replace('\r\n', '\n').replace('\r', '\n')
     if myClippingsTxt.strip() == '':

--- a/readers/ParseKindleMyClippingsTxt.py
+++ b/readers/ParseKindleMyClippingsTxt.py
@@ -164,9 +164,9 @@ _MONTH_NAMES_SHORT = {
 
 def _detectLanguageAndType(status):
     words = status.split(None, _MAX_NR_OF_START_WORDS)
-    for nrWords in xrange(0, _MAX_NR_OF_START_WORDS):
+    for nrWords in range(0, _MAX_NR_OF_START_WORDS):
         key = ' '.join(words[:nrWords+1])
-        if _LANG_AND_KIND_DETECT_BY_START_WORDS.has_key(key):
+        if key in _LANG_AND_KIND_DETECT_BY_START_WORDS:
             return _LANG_AND_KIND_DETECT_BY_START_WORDS[key]
     return (None, None)
     
@@ -241,22 +241,22 @@ def _getDateTime(status, language):
         # Otherwise the last number is the year (and 2000 should be added).
         words = re.split(r"[,;]?\s", status)
         for word in words:
-            if _MONTH_NAMES[language].has_key(word):
+            if word in _MONTH_NAMES[language]:
                 month = _MONTH_NAMES[language][word]
                 break
         if not month:
             for word in words:
-                if _MONTH_NAMES_SHORT[language].has_key(word):
+                if word in _MONTH_NAMES_SHORT[language]:
                     month = _MONTH_NAMES_SHORT[language][word]
                     break
         if not month: # Some languages should be lower case, but Amazon seems to have capitalized the month.
             for word in words:
-                if _MONTH_NAMES[language].has_key(word.lower()):
+                if word.lower() in _MONTH_NAMES[language]:
                     month = _MONTH_NAMES[language][word.lower()]
                     break
         if not month:
             for word in words:
-                if _MONTH_NAMES_SHORT[language].has_key(word.lower()):
+                if word.lower() in _MONTH_NAMES_SHORT[language]:
                     month = _MONTH_NAMES_SHORT[language][word.lower()]
                     break
         if month:
@@ -300,15 +300,15 @@ def _getTitleAndAuthor(line):
 # read "My Clippings.txt" and extract all annotations
 def FromFileName(myClippingsFilePath):
     try:
-        with file( myClippingsFilePath, 'rb' ) as f: # file is UTF-8 => read binary!
+        with open(myClippingsFilePath, 'r', encoding='utf-8') as f: # file is UTF-8
             return FromUtf8String( f.read() )
-    except Exception as e:
+    except IOError as e:
         log('ERROR', "Error trying to read clippings file: %s" % (str(e),))
         return []
 
 def FromUtf8String(myClippingsTxt):
     # remove BOM(s) a.k.a. zero width space
-    myClippingsTxt = myClippingsTxt.replace('\xef\xbb\xbf', '')
+    myClippingsTxt = myClippingsTxt.replace('﻿', '')
     # normalize newlines
     myClippingsTxt = myClippingsTxt.replace('\r\n', '\n').replace('\r', '\n')
     if myClippingsTxt.strip() == '':
@@ -392,15 +392,15 @@ if __debug__ and __name__ == '__main__':
             names[language] = ({}, {}, {}, {}) # month long/short, week day long/short
             for localeName in localeNames[1:]:
                 locale.setlocale(locale.LC_TIME, localeName)
-                for month in xrange(1,12+1):
+                for month in range(1,12+1):
                     days = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-                    for day in xrange(1,days[month-1]+1):
+                    for day in range(1,days[month-1]+1):
                         date = datetime.date(2012,month,day)
                         for idx, timeFormat in enumerate(["%B", "%b", "%A", "%a"]):
                             try:
                                 name = date.strftime(timeFormat)
                                 dic = names[language][idx]
-                                if dic.has_key(name):
+                                if name in dic:
                                     if dic[name] is not None and dic[name] != month:
                                         dic[name] = None # ambiguous; not really a month or day name
                                 else:
@@ -413,10 +413,10 @@ if __debug__ and __name__ == '__main__':
             print("_MONTH_NAMES = {" if longNames else "_MONTH_NAMES_SHORT = {")
             for langs in localeNameTuples:
                 lang = langs[0]
-                if not names.has_key(lang):
+                if lang not in names:
                     continue
                 line = "    '%s': {" % lang
-                for value, key in sorted([(v,k) for k,v in names[lang][0 if longNames else 1].items()]):
+                for value, key in sorted([(v,k) for k,v in list(names[lang][0 if longNames else 1].items())]):
                     if value > 6 and not '\n' in line:
                         line = re.sub(r"\s*$", "\n"+" "*11, line)
                     line += "'%s': %s, " % (key, value)


### PR DESCRIPTION
**Key changes**:
- Ran kindle related files through a py2 -> 3 converter.
- Reading `MyClippings.txt` as bytes did not work after converting to py3. Instead, read it as a string with the proper encoding. Then the remaining transformations all occur on the string instead of the bytes.
- Don't catch `Exception`, try to catch a more concrete `IOError` instead. Otherwise it's difficult to debug all these py2->3 failures, they would be swallowed by the catch.

**Testing Done**:
- Imported changed plugin into calibre and ensured it can import annotations from my kindle. Seems to work as expected, I think all of them were pulled.
- Did **not** run the unit tests, I'm not sure how to (not a Python developer). Perhaps the README can be updated to explain this? Thanks