### PR TITLE
Fixes detection of a device name, when Calibre MTP driver is being used

### DIFF
--- a/action.py
+++ b/action.py
@@ -360,8 +360,17 @@ class AnnotationsAction(InterfaceAction, Logger):
         if self.connected_device is not None:
             self._log_location("Have device")
             self.launch_library_scanner()
-            primary_name = self.connected_device.name.split()[0]
-            self.fetch_usb_device_annotations(primary_name)
+            self.fetch_usb_device_annotations(self.get_connected_device_primary_name())
+
+    def get_connected_device_primary_name(self):
+        if self.connected_device.name == 'MTP Device Interface':
+            # the MTP driver wraps itself around device name
+            device_name = self.connected_device.get_device_information()[0]
+        else:
+            # other drivers makes device name easily accessible
+            device_name = self.connected_device.name
+
+        return device_name.split()[0]
 
     def fetch_usb_device_annotations(self, reader_app):
         """
@@ -1247,7 +1256,7 @@ class AnnotationsAction(InterfaceAction, Logger):
 
                 else:
                     usb_reader_classes = list(USBReader.get_usb_reader_classes().keys())
-                    primary_name = self.connected_device.name.split()[0]
+                    primary_name = self.get_connected_device_primary_name()
                     if primary_name in usb_reader_classes:
                         haveDevice = True
                         fetch_tootip = _('Fetch annotations from {0}').format(self.connected_device.gui_name)

--- a/action.py
+++ b/action.py
@@ -364,10 +364,15 @@ class AnnotationsAction(InterfaceAction, Logger):
 
     def get_connected_device_primary_name(self):
         if self.connected_device.name == 'MTP Device Interface':
-            # the MTP driver wraps itself around device name
+            # get actual device name from the MTP driver (used for Android devices)
             device_name = self.connected_device.get_device_information()[0]
+
+            # group all Onyx devices under same name, because they behave the same
+            import re
+            if re.compile(r"^(Nova|Poke|Note|MAX)").match(device_name):
+                device_name = 'Boox'
         else:
-            # other drivers makes device name easily accessible
+            # non-Android devices have dedicated drivers
             device_name = self.connected_device.name
 
         return device_name.split()[0]


### PR DESCRIPTION
While adding support (another PR) for an Android device connected to macOS I've noticed, that it is never detected.

Turned out, that the `self.connected_device.name` property in the `action.py` file always returned `MTP Device Interface`, when Calibre's MTP device driver was used (it will be used for all Android-based devices on macOS). This of course completely ruined device detection in this annotations plugin.

For example, the Kindle driver was returning the `Kindle 2/3/4/Touch/PaperWhite/Voyage Device Interface` in the `self.connected_device.name` property, which was perfectly fine.

The fix adds a wrapper for the MTP driver and instead of using `self.connected_device.name` actually uses `self.connected_device..get_device_information()[0]`

---

Here is device info from Kindle:

```
self.connected_device:
<calibre.devices.kindle.driver.KINDLE2 object at 0x10d263af0>

self.connected_device.get_device_information:
('Amazon Kindle', '', '', '', {'main': {'prefix': '/Volumes/Kindle/', 'device_store_uuid': '87ef71fd-cfd6-4573-b290-aed48a762062', 'date_last_connected': '2022-02-18T22:02:43.700440+00:00', 'device_name': 'Amazon Kindle', 'calibre_version': '5.36.0', 'location_code': 'main', 'last_library_uuid': None}})

self.connected_device.gui_name:
Amazon Kindle

self.connected_device.name:
Kindle 2/3/4/Touch/PaperWhite/Voyage Device Interface
```

Here is device info from the Android device:

```
self.connected_device:
<calibre.devices.mtp.driver.MTP_DEVICE object at 0x10d2697f0>

self.connected_device.get_device_information:
('Nova3', '1.0', '1.0', '', {})

self.connected_device.gui_name:
MTP device

self.connected_device.name:
MTP Device Interface
```

Additionally, I've simplified Onyx Boox device handling to allow support for them using a single USB driver.