### PR TITLE
Enable support for import file chooser

### DIFF
--- a/action.py
+++ b/action.py
@@ -23,11 +23,11 @@ from zipfile import ZipFile
 from calibre.devices.usbms.driver import debug_print
 
 try:
-    from PyQt5.Qt import (pyqtSignal, Qt, QApplication, QIcon, QMenu, QPixmap,
+    from PyQt5.Qt import (pyqtSignal, Qt, QApplication, QIcon, QMenu, QMessageBox, QPixmap,
                           QTimer, QToolButton, QUrl)
 except ImportError as e:
     debug_print("Error loading QT5: ", e)
-    from PyQt4.Qt import (pyqtSignal, Qt, QApplication, QIcon, QMenu, QPixmap,
+    from PyQt4.Qt import (pyqtSignal, Qt, QApplication, QIcon, QMenu, QMessageBox, QPixmap,
                           QTimer, QToolButton, QUrl)
 
 from calibre.constants import DEBUG, isosx, iswindows
@@ -53,7 +53,7 @@ from calibre_plugins.annotations.annotations import merge_annotations, merge_ann
 from calibre_plugins.annotations.annotations_db import AnnotationsDB
 
 from calibre_plugins.annotations.common_utils import (
-    CoverMessageBox, HelpView, ImportAnnotationsDialog, IndexLibrary,
+    CoverMessageBox, HelpView, ImportAnnotationsTextDialog, ImportAnnotationsFileDialog, IndexLibrary,
     Logger, ProgressBar, Struct,
     get_cc_mapping, get_clippings_cid, get_icon, get_pixmap, get_resource_files,
     get_selected_book_mi, plugin_tmpdir,
@@ -818,13 +818,22 @@ class AnnotationsAction(InterfaceAction, Logger):
             reader_app = exporting_apps[reader_app_class]
 
             # Open the Import Annotations dialog
-            raw_xml = ImportAnnotationsDialog(self, reader_app, reader_app_class).text
-            if(raw_xml):
+            if reader_app_class.SUPPORTS_FILE_CHOOSER:
+                raw_data = ImportAnnotationsFileDialog(self, reader_app_class).text()
+            else:
+                raw_data = ImportAnnotationsTextDialog(self, reader_app, reader_app_class).text()
+            if(raw_data):
                 # Instantiate reader_app_class
                 rac = reader_app_class(self)
-                success = rac.parse_exported_highlights(raw_xml)
+                success = rac.parse_exported_highlights(raw_data)
                 if not success:
-                    self._log("errors parsing raw_xml")
+                    self._log("errors parsing data for import")
+                    msg = QMessageBox()
+                    msg.setIcon(QMessageBox.Critical)
+                    msg.setText("Import Error")
+                    msg.setInformativeText('Error parsing data.')
+                    msg.setWindowTitle("Import Error")
+                    msg.exec_()
 
                 # Present the imported books, get a list of books to add to calibre
                 if rac.annotated_book_list:

--- a/common_utils.py
+++ b/common_utils.py
@@ -24,10 +24,10 @@ import collections
 try:
     from PyQt5.QtCore import pyqtSignal
     from PyQt5.Qt import (Qt, QAction, QApplication,
-                QCheckBox, QComboBox, QDial, QDialog, QDialogButtonBox, QDoubleSpinBox, QIcon,
-                QKeySequence, QLabel, QLineEdit, QPixmap, QProgressBar, QPlainTextEdit,
-                QRadioButton, QSize, QSizePolicy, QSlider, QSpinBox, QThread, QUrl,
-                QVBoxLayout, QHBoxLayout, QFont
+                QCheckBox, QComboBox, QDial, QDialog, QDialogButtonBox, QDoubleSpinBox,
+                QFileDialog, QIcon, QKeySequence, QLabel, QLineEdit, QPixmap, QProgressBar,
+                QPlainTextEdit, QRadioButton, QSize, QSizePolicy, QSlider, QSpinBox, QThread,
+                QUrl, QVBoxLayout, QHBoxLayout, QFont
                 )
     from PyQt5.Qt import QTextEdit as QWebView # Renaming to keep backwards compatibility.
     from PyQt5.uic import compileUi
@@ -35,10 +35,10 @@ except ImportError as e:
     from calibre.devices.usbms.driver import debug_print
     debug_print("Error loading QT5: ", e)
     from PyQt4.Qt import (Qt, QAction, QApplication,
-                QCheckBox, QComboBox, QDial, QDialog, QDialogButtonBox, QDoubleSpinBox, QIcon,
-                QKeySequence, QLabel, QLineEdit, QPixmap, QProgressBar, QPlainTextEdit,
-                QRadioButton, QSize, QSizePolicy, QSlider, QSpinBox, QThread, QUrl,
-                QVBoxLayout, QHBoxLayout, QFont,
+                QCheckBox, QComboBox, QDial, QDialog, QDialogButtonBox, QDoubleSpinBox,
+                QFileDialog, QIcon, QKeySequence, QLabel, QLineEdit, QPixmap, QProgressBar,
+                QPlainTextEdit, QRadioButton, QSize, QSizePolicy, QSlider, QSpinBox, QThread,
+                QUrl, QVBoxLayout, QHBoxLayout, QFont,
                 pyqtSignal)
     from PyQt4.QtWebKit import QWebView
     from PyQt4.uic import compileUi
@@ -325,7 +325,43 @@ class UnknownAnnotationTypeException(Exception):
 
 '''     Dialogs         '''
 
-class ImportAnnotationsDialog(QDialog):
+class ImportAnnotationsFileDialog(QFileDialog):
+    """
+    Subclass enabling choosing a file
+    """
+
+    def __init__(self, parent, rac):
+        QFileDialog.__init__(self, parent.gui)
+        self.opts = parent.opts
+        self.parent = parent
+        self.rac = rac
+        self.setFileMode(QFileDialog.ExistingFile)
+        self.setNameFilter(rac.import_file_name_filter)
+        self.setOption(QFileDialog.DontUseNativeDialog)
+        self.setWindowIcon(self.opts.icon)
+        self.setWindowTitle(rac.import_dialog_title)
+
+        # Add help button:
+        hbl = QHBoxLayout()
+        layout = self.layout()
+        self.dialogButtonBox = QDialogButtonBox(QDialogButtonBox.Help)
+        self.dialogButtonBox.clicked.connect(self.help_clicked)
+        hbl.addWidget(self.dialogButtonBox)
+        layout.addLayout(hbl, layout.rowCount(), 0, 1, -1)
+
+        # Show dialog and get selected files
+        self.exec_()
+        self.files = self.selectedFiles()
+
+    def help_clicked(self, button):
+        hv = HelpView(self, self.opts.icon, self.opts.prefs, html=self.rac.import_help_text)
+        hv.show()
+
+    def text(self):
+        if len(self.files) >= 1:
+            return self.files[0]
+
+class ImportAnnotationsTextDialog(QDialog):
     def __init__(self, parent, friendly_name, rac):
         #self.dialog = QDialog(parent.gui)
         QDialog.__init__(self, parent.gui)
@@ -352,9 +388,8 @@ class ImportAnnotationsDialog(QDialog):
         l.addWidget(self.dialogButtonBox)
 
         self.rejected.connect(self.close)
-
         self.exec_()
-        self.text = str(self.pte.toPlainText())
+        self.pteText = str(self.pte.toPlainText())
 
     def close(self):
         # Catch ESC and close button
@@ -376,7 +411,7 @@ class ImportAnnotationsDialog(QDialog):
             self.close()
 
     def text(self):
-        return unicode(self.pte.toPlainText())
+        return unicode(self.pteText)
 
 
 class CoverMessageBox(QDialog, Ui_Dialog):

--- a/reader_app_support.py
+++ b/reader_app_support.py
@@ -68,6 +68,7 @@ class ReaderApp(object):
     reader_app_classes = None
     MAX_ELEMENT_DEPTH = 6
     SUPPORTS_EXPORTING = False
+    SUPPORTS_FILE_CHOOSER = False
     SUPPORTS_FETCHING = False
 
     NSTimeIntervalSince1970 = 978307200.0

--- a/readers/SampleExportingApp.py
+++ b/readers/SampleExportingApp.py
@@ -21,8 +21,7 @@ class SampleExportingApp(ExportingReader):
 
     # app_name should be the same as the class name
     app_name = 'SampleExportingApp'
-    import_fingerprint = False
-    import_dialog_title = "Import {0} annotations".format(app_name)
+
     if True:
         import_help_text = ('''
             <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
@@ -81,9 +80,16 @@ class SampleExportingApp(ExportingReader):
             </html>''')
 
     initial_dialog_text = 'Junk'
+    import_fingerprint = False
+    import_dialog_title = "Import {0} annotations".format(app_name)
 
     # Change this to True when developing a new class from this template
     SUPPORTS_EXPORTING = True
+
+    # Change this to True to use a file chooser instead of text input box for import
+    SUPPORTS_FILE_CHOOSER = False
+    import_file_name_filter = "All files (*)"
+
 
     # Sample annotations, indexed by timestamp. Note that annotations may have
     # highlight_text, note_text, or both. 'location' might reference a page number from


### PR DESCRIPTION
Some reader classes may want to have a user select a file, instead of
presenting a text box. This adds support for the feature.

It will be used by the Moon+ reader class.

Screenshot:

![image](https://user-images.githubusercontent.com/429763/163838758-fd437184-2c56-403d-932f-95183cee7f3c.png)
