### PR TITLE
Detect MTP device name within same thread on Windows

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,7 @@ class AnnotationsPlugin(InterfaceActionBase):
     description         = 'Import annotations'
     supported_platforms = ['linux', 'osx', 'windows']
     author              = 'David Forrester'
-    version             = (1, 17, 0)
+    version             = (1, 17, 1)
     minimum_calibre_version = (1, 0, 0)
 
     actual_plugin       = 'calibre_plugins.annotations.action:AnnotationsAction'

--- a/about.txt
+++ b/about.txt
@@ -1,4 +1,7 @@
 Version history:
+1.17.1 - 29 April 2022
+• Fix: Use "current_friendly_name" for MTP devices
+
 1.17.0 - 10 April 2022
 • New: Added support AlReaderX reader app on the Boox Android-based devices. Thanks to @aik099.
 • Change: Some code cleanup.

--- a/action.py
+++ b/action.py
@@ -364,6 +364,7 @@ class AnnotationsAction(InterfaceAction, Logger):
 
     def get_connected_device_primary_name(self):
         if self.connected_device.name == 'MTP Device Interface':
+            self._log_location("get_connected_device_primary_name - Have MTP device - self.get_connected_device_primary_name='%s'" % self.connected_device.current_friendly_name)
             # get actual device name from the MTP driver (used for Android devices)
             device_name = self.connected_device.current_friendly_name
 

--- a/action.py
+++ b/action.py
@@ -365,7 +365,7 @@ class AnnotationsAction(InterfaceAction, Logger):
     def get_connected_device_primary_name(self):
         if self.connected_device.name == 'MTP Device Interface':
             # get actual device name from the MTP driver (used for Android devices)
-            device_name = self.connected_device.get_device_information()[0]
+            device_name = self.connected_device.current_friendly_name
 
             # group all Onyx devices under same name, because they behave the same
             import re

--- a/action.py
+++ b/action.py
@@ -672,7 +672,7 @@ class AnnotationsAction(InterfaceAction, Logger):
         # takes some time for the device to be recognized.
         self.opts['device_name'] = None
         if self.connected_device:
-            self.opts['device_name'] = self.connected_device.get_device_information()[0]
+            self.opts['device_name'] = self.connected_device.current_friendly_name
         self.opts['mount_point'] = self.mount_point
         return self.opts
 


### PR DESCRIPTION
This PR is a solution for a problem, described in the https://www.mobileread.com/forums/showpost.php?p=4216803&postcount=1032 post, where connecting an Android device on Windows results in this error:

```
calibre, version 5.41.0
ERROR: Unhandled exception: <b>ThreadingViolation</b>:You cannot use the MTP driver from a thread other than the thread in which startup() was called
```

These code changes were made by @davidfor in the https://www.mobileread.com/forums/showpost.php?p=4217190&postcount=1033 post.