### PR TITLE
Do case-insensitive Kindle clippings file parsing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,7 @@ class AnnotationsPlugin(InterfaceActionBase):
     description         = 'Import annotations'
     supported_platforms = ['linux', 'osx', 'windows']
     author              = 'David Forrester'
-    version             = (1, 17, 0)
+    version             = (1, 17, 2)
     minimum_calibre_version = (1, 0, 0)
 
     actual_plugin       = 'calibre_plugins.annotations.action:AnnotationsAction'

--- a/about.txt
+++ b/about.txt
@@ -1,4 +1,7 @@
 Version history:
+1.17.2 - 10 May 2022
+• Fix: Change regex used for Kindle "Clippings.txt" to case insensitive. Kindle set to pt_BR uses lower case version of strings.
+
 1.17.0 - 10 April 2022
 • New: Added support AlReaderX reader app on the Boox Android-based devices. Thanks to @aik099.
 • Change: Some code cleanup.


### PR DESCRIPTION
This PR is a solution for a problem, described in the https://www.mobileread.com/forums/showpost.php?p=4220076&postcount=1046 post, where the Kindle clippings file wasn't parsed correctly on the `pt_BR` language where markup language case was different (the `Page` word in Portuguese was in lowercase).

These code changes were made by @davidfor in the https://www.mobileread.com/forums/showpost.php?p=4220751&postcount=1049 post.