### PR TITLE
2 small changes to import annotations from external services 

### DIFF
--- a/action.py
+++ b/action.py
@@ -822,7 +822,14 @@ class AnnotationsAction(InterfaceAction, Logger):
             if reader_app_class.SUPPORTS_FILE_CHOOSER:
                 raw_data = ImportAnnotationsFileDialog(self, reader_app_class).text()
             else:
-                raw_data = ImportAnnotationsTextDialog(self, reader_app, reader_app_class).text()
+                try:
+                    if reader_app_class.REQUIRES_TEST_INPUT == True:
+                       raw_data = ImportAnnotationsTextDialog(self, reader_app, reader_app_class).text()
+                    else:
+                        raw_data = "-"
+                except AttributeError:
+                    raw_data = ImportAnnotationsTextDialog(self, reader_app, reader_app_class).text()
+                
             if(raw_data):
                 # Instantiate reader_app_class
                 rac = reader_app_class(self)

--- a/action.py
+++ b/action.py
@@ -803,14 +803,22 @@ class AnnotationsAction(InterfaceAction, Logger):
         supported_reader_apps = ReaderApp.get_reader_app_classes()
         reader_app_class = supported_reader_apps[reader_app]
 
+        try:
+            requires_book_selected = reader_app_class.REQUIRES_BOOK_SELECTED
+        except AttributeError:
+            requires_book_selected = True
+
         # Save a reference for merge_annotations
         self.reader_app_class = reader_app_class
 
-        self.selected_mi = get_selected_book_mi(self.get_options(),
-                                                msg=self.SELECT_DESTINATION_MSG,
-                                                det_msg=self.SELECT_DESTINATION_DET_MSG)
-        if not self.selected_mi:
-            return
+        if requires_book_selected:
+            self.selected_mi = get_selected_book_mi(self.get_options(),
+                                                    msg=self.SELECT_DESTINATION_MSG,
+                                                    det_msg=self.SELECT_DESTINATION_DET_MSG)
+            if not self.selected_mi:
+                return
+        else:
+            self.selected_mi = None
 
         ra_confidence = reader_app_class.import_fingerprint
 

--- a/readers/SampleExportingApp.py
+++ b/readers/SampleExportingApp.py
@@ -94,7 +94,7 @@ class SampleExportingApp(ExportingReader):
     # If this is set to true, it means the class needs the user to select a book prior to invoking this action.
     # If a book isn't selected, the user will receive a warning and nothing will happen
     # If this is set to false, the user can call the class with 0 or more books selected, it's up to you to handle all scenarios
-    REQUIRES_BOOK_SELECTED = False
+    REQUIRES_BOOK_SELECTED = True
 
     # Change this to True to use a file chooser instead of text input box for import
     SUPPORTS_FILE_CHOOSER = False

--- a/readers/SampleExportingApp.py
+++ b/readers/SampleExportingApp.py
@@ -86,6 +86,16 @@ class SampleExportingApp(ExportingReader):
     # Change this to True when developing a new class from this template
     SUPPORTS_EXPORTING = True
 
+    # If this is set to true, a text dialog will be shown prior to calling parse_exported_highlights
+    # and the contents of the dialog will be passed in via the raw parameter
+    # If set to false, no dialog will be displayed and parse_exported_highlights will be called with raw == "-"
+    REQUIRES_TEST_INPUT = True
+
+    # If this is set to true, it means the class needs the user to select a book prior to invoking this action.
+    # If a book isn't selected, the user will receive a warning and nothing will happen
+    # If this is set to false, the user can call the class with 0 or more books selected, it's up to you to handle all scenarios
+    REQUIRES_BOOK_SELECTED = False
+
     # Change this to True to use a file chooser instead of text input box for import
     SUPPORTS_FILE_CHOOSER = False
     import_file_name_filter = "All files (*)"


### PR DESCRIPTION
This change does 2 things:

1. It allows extensions of ExportingReader the option to work without a book being selected
2. It allows extensions of ExportingReader to work without a text input dialog prior to code execution

Both changes support an extension I'm building that will pull in annotations from an API.