### PR TITLE
Q&D fix of the import imp deprecation in 3.12

### DIFF
--- a/about.txt
+++ b/about.txt
@@ -1,4 +1,7 @@
 Version history:
+1.17.13b - 29 April 2024
+• Fix: Quick & dirty fix of the import imp deprecation.
+
 1.17.13 - 19 July 2022
 • Fix: Qt6 compatibility - Yet another enum issue.
 


### PR DESCRIPTION
Hi,

I think this could be done better, I only took the recipe from https://github.com/python/cpython/issues/104212#issuecomment-1560813974

But at least I can import my annotations again :)

Regards,

